### PR TITLE
[DEL-155] Fix PWA start URL to redirect to dashboard instead of landing page

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(gh pr view:*)",
       "mcp__laravel-boost__search-docs",
       "mcp__laravel-boost__application-info",
-      "mcp__laravel-boost__get-config"
+      "mcp__laravel-boost__get-config",
+      "mcp__herd__get_all_sites"
     ],
     "deny": []
   },

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -2,7 +2,7 @@
   "name": "Delight",
   "short_name": "Delight",
   "description": "Track your Bible reading habits and build consistency with streak tracking and progress visualization",
-  "start_url": "/",
+  "start_url": "/dashboard",
   "display": "standalone",
   "background_color": "#f9fafb",
   "theme_color": "#3366CC",


### PR DESCRIPTION
The PWA was opening the landing page for all users, including logged-in users. Changed start_url from "/" to "/dashboard" so that:
- Logged-in users see the dashboard directly
- Logged-out users get redirected to login by auth middleware
- Landing page is never shown in PWA context

🤖 Generated with [Claude Code](https://claude.ai/code)