### PR TITLE
[DEL-157] Add PWA announcement email feature

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,10 @@
       "mcp__laravel-boost__get-config",
       "mcp__herd__get_all_sites",
       "mcp__github__get_pull_request_files",
-      "mcp__laravel-boost__list-routes"
+      "mcp__laravel-boost__list-routes",
+      "Bash(php artisan make:mail:*)",
+      "Bash(php artisan make:command:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": []
   },

--- a/app/Console/Commands/SendPwaAnnouncement.php
+++ b/app/Console/Commands/SendPwaAnnouncement.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\PwaAnnouncement;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendPwaAnnouncement extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:pwa-announcement {--dry-run : Show how many users would receive the email without sending}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send PWA announcement email to all users';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $users = User::all();
+        $userCount = $users->count();
+        
+        if ($userCount === 0) {
+            $this->error('No users found to send emails to.');
+            return Command::FAILURE;
+        }
+        
+        if ($this->option('dry-run')) {
+            $this->info("Dry run: Would send PWA announcement to {$userCount} users");
+            return Command::SUCCESS;
+        }
+        
+        if (!$this->confirm("Send PWA announcement to {$userCount} users?")) {
+            $this->info('Email sending cancelled.');
+            return Command::SUCCESS;
+        }
+        
+        $this->info("Sending PWA announcement to {$userCount} users...");
+        $progressBar = $this->output->createProgressBar($userCount);
+        $progressBar->start();
+        
+        $sent = 0;
+        $failed = 0;
+        
+        foreach ($users as $user) {
+            try {
+                Mail::to($user->email)->send(new PwaAnnouncement($user));
+                $sent++;
+            } catch (\Exception $e) {
+                $this->newLine();
+                $this->error("Failed to send to {$user->email}: " . $e->getMessage());
+                $failed++;
+            }
+            
+            $progressBar->advance();
+        }
+        
+        $progressBar->finish();
+        $this->newLine(2);
+        
+        $this->info("Email sending complete!");
+        $this->info("Sent: {$sent}");
+        
+        if ($failed > 0) {
+            $this->warn("Failed: {$failed}");
+        }
+        
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/TestPwaEmail.php
+++ b/app/Console/Commands/TestPwaEmail.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\PwaAnnouncement;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class TestPwaEmail extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'test:pwa-email {email?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send a test PWA announcement email to test locally with Mailpit';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $email = $this->argument('email') ?? 'test@example.com';
+        
+        // Get or create test user
+        $user = User::where('email', $email)->first();
+        
+        if (!$user) {
+            $user = User::factory()->create([
+                'name' => 'Test User',
+                'email' => $email
+            ]);
+            $this->info("Created test user: {$email}");
+        }
+        
+        // Send the email
+        Mail::to($user->email)->send(new PwaAnnouncement($user));
+        
+        $this->info("PWA announcement email sent to: {$user->email}");
+        $this->info("Check Mailpit at: http://localhost:8025");
+        
+        return Command::SUCCESS;
+    }
+}

--- a/app/Mail/PwaAnnouncement.php
+++ b/app/Mail/PwaAnnouncement.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PwaAnnouncement extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public User $user
+    ) {}
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Install Delight on Your Home Screen - Never Miss Your Reading Streak',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.pwa-announcement',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/resources/views/emails/pwa-announcement.blade.php
+++ b/resources/views/emails/pwa-announcement.blade.php
@@ -1,0 +1,103 @@
+@extends('emails.layouts.base')
+
+@section('title', 'Install Delight on Your Home Screen')
+
+@section('content')
+<h2 class="greeting">📱 Great news, {{ $user->name }}!</h2>
+
+<p class="message">
+    Delight now works like a mobile app when installed on your phone or tablet. 
+    Get instant access to your Bible reading tracker right from your home screen!
+</p>
+
+<div class="notice notice-success">
+    <p class="notice-title">🎉 New Feature Available</p>
+    <p class="notice-text">
+        Install Delight as a Progressive Web App - no app store needed!
+    </p>
+</div>
+
+<div class="content-card">
+    <h3 style="margin: 0 0 16px 0; font-size: 18px; font-weight: 600; color: #111827;">Why Install on Your Home Screen?</h3>
+
+    <div style="margin-bottom: 16px;">
+        <strong style="color: #374151;">⚡ Instant Access:</strong>
+        <span style="color: #6b7280;">No more hunting for browser tabs - tap the icon and you're in!</span>
+    </div>
+
+    <div style="margin-bottom: 16px;">
+        <strong style="color: #374151;">🔥 Quick Streak Checking:</strong>
+        <span style="color: #6b7280;">See your reading progress and maintain your streak faster than ever.</span>
+    </div>
+
+    <div style="margin-bottom: 16px;">
+        <strong style="color: #374151;">📊 Faster Progress Updates:</strong>
+        <span style="color: #6b7280;">Log your daily reading and view your book completion grid instantly.</span>
+    </div>
+
+    <div>
+        <strong style="color: #374151;">📱 App-Like Experience:</strong>
+        <span style="color: #6b7280;">Feels like a native app without taking up extra storage space.</span>
+    </div>
+</div>
+
+<div class="notice notice-info">
+    <p class="notice-title">📋 How to Install</p>
+    <p class="notice-text">
+        <strong>Important:</strong> You must visit Delight in your web browser first, then install from there.<br><br>
+        <strong>iPhone/iPad (Safari):</strong> Tap the Share button (□↑) → "Add to Home Screen"<br>
+        <strong>Android (Chrome):</strong> Tap the menu (⋮) → "Install app" or "Add to Home Screen"<br>
+        <strong>Desktop (Chrome/Edge):</strong> Look for the install icon (⊞) in the address bar
+    </p>
+</div>
+
+<div class="button-container">
+    <a href="{{ url('/dashboard') }}" class="button">Open Delight & Install</a>
+</div>
+
+<p class="message">
+    Once installed, Delight appears as an icon on your home screen. 
+    Tap it anytime to quickly log your reading and keep your streak alive!
+</p>
+
+<div class="content-card">
+    <h3 style="margin: 0 0 16px 0; font-size: 18px; font-weight: 600; color: #111827;">See It in Action</h3>
+    <p style="margin: 0 0 16px 0; color: #6b7280;">
+        Watch this quick tutorial showing how easy installation is:
+    </p>
+    
+    <div style="text-align: center; margin: 16px 0;">
+        <a href="https://twitter.com/SaintAriyel/status/1963013173403124047?ref_src=twsrc%5Etfw" style="display: inline-block; background: #1da1f2; color: white !important; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-size: 14px; font-weight: 600;">
+            🎥 Watch Tutorial Video
+        </a>
+    </div>
+</div>
+
+<hr class="divider">
+
+<p class="message text-small text-muted">
+    This update makes building your Bible reading habit even more convenient. 
+    Install today and never miss logging your daily progress!
+</p>
+
+<div class="content-card">
+    <h3 style="margin: 0 0 16px 0; font-size: 18px; font-weight: 600; color: #111827;">Need More Help?</h3>
+    
+    <div style="margin-bottom: 12px;">
+        <strong style="color: #374151;">🟢 Chrome Guide:</strong>
+        <a href="https://support.google.com/chrome/answer/9658361" class="text-link" style="color: #3366CC;">Install web apps</a>
+    </div>
+    
+    <div>
+        <strong style="color: #374151;">📖 General PWA Guide:</strong>
+        <a href="https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Installing" class="text-link" style="color: #3366CC;">Installing PWAs (Mozilla)</a>
+    </div>
+</div>
+@endsection
+
+@section('footer-extra')
+<p class="footer-text">
+    <a href="{{ url('/dashboard') }}" class="footer-link">Go to Dashboard</a> |
+    <a href="{{ url('/logs') }}" class="footer-link">View Reading History</a>
+</p>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,6 @@ if (app()->environment('local') || app()->environment('staging')) {
     Route::get('/telescope', function () {
         return redirect('/telescope/requests');
     });
-    
 }
 
 Route::get('/', function () {


### PR DESCRIPTION
- Create PwaAnnouncement mailable with user-specific content
- Add pwa-announcement.blade.php email template with:
  - Clean Twitter tutorial video button (no fake embed)
  - Step-by-step installation instructions for all major browsers
  - Browser requirement emphasis for PWA installation
  - Help section at bottom with Chrome + Mozilla guides
- Add TestPwaEmail command for local testing with Mailpit
- Email highlights actual Delight features: streak tracking, progress logging
- Mobile-responsive design matching existing email templates

🤖 Generated with [Claude Code](https://claude.ai/code)