### PR TITLE
[DEL-164] Fix extra padding in real-time reading log refresh

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -21,7 +21,8 @@
       "mcp__laravel-boost__list-routes",
       "Bash(php artisan make:mail:*)",
       "Bash(php artisan make:command:*)",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "mcp__laravel-boost__get-absolute-url"
     ],
     "deny": []
   },

--- a/app/Http/Controllers/ReadingLogController.php
+++ b/app/Http/Controllers/ReadingLogController.php
@@ -213,6 +213,11 @@ class ReadingLogController extends Controller
                 return response($cardsHtml);
             }
 
+            // If this is a refresh request (from readingLogAdded trigger), return just the list
+            if ($request->has('refresh')) {
+                return view('partials.reading-log-list', compact('logs'));
+            }
+
             // Otherwise, return the page container for HTMX navigation
             return view('partials.logs-page', compact('logs'));
         }

--- a/resources/views/partials/logs-content.blade.php
+++ b/resources/views/partials/logs-content.blade.php
@@ -8,12 +8,6 @@
             <span class="ml-3 text-gray-600 dark:text-gray-400">Loading readings...</span>
         </div>
 
-        <div id="reading-list-container"
-            hx-trigger="readingLogAdded from:body"
-            hx-get="{{ route('logs.index') }}"
-            hx-target="this"
-            hx-swap="innerHTML">
-            @include('partials.reading-log-list', compact('logs'))
-        </div>
+        @include('partials.reading-log-list', compact('logs'))
     </div>
 </div>

--- a/resources/views/partials/reading-log-list.blade.php
+++ b/resources/views/partials/reading-log-list.blade.php
@@ -3,7 +3,11 @@
 
 @if ($logs->count() > 0)
     {{-- Reading Log Entries Container - Simplified architecture for consistent spacing --}}
-    <div id="log-list" class="relative">
+    <div id="log-list" class="relative"
+        hx-trigger="readingLogAdded from:body"
+        hx-get="{{ route('logs.index') }}?refresh=1"
+        hx-target="this"
+        hx-swap="outerHTML">
         {{-- Content Container - All cards render here with consistent spacing --}}
         <div id="log-list-content" class="space-y-4">
             @foreach ($logs as $logsForDay)


### PR DESCRIPTION
When adding a reading log while viewing the history logs page, the content refreshes in real-time but displays with extra padding around it. This creates visual inconsistency and layout issues.