### PR TITLE
[DEL-165] Fix infinite scroll pagination in reading log history

### DIFF
--- a/app/Services/ReadingLogService.php
+++ b/app/Services/ReadingLogService.php
@@ -395,6 +395,7 @@ class ReadingLogService
     /**
      * Render reading log cards HTML for infinite scroll responses.
      * Takes a collection of grouped logs and returns concatenated card HTML.
+     * Includes infinite scroll sentinel if there are more pages.
      */
     public function renderReadingLogCardsHtml($logs): string
     {
@@ -412,6 +413,13 @@ class ReadingLogService
                     'logsForDay' => $logsForDay
                 ])->render();
             }
+        }
+        
+        // Add infinite scroll sentinel if there are more pages
+        if ($logs->hasMorePages()) {
+            $cardsHtml .= view('partials.infinite-scroll-sentinel', [
+                'logs' => $logs
+            ])->render();
         }
         
         return $cardsHtml;

--- a/resources/views/layouts/authenticated.blade.php
+++ b/resources/views/layouts/authenticated.blade.php
@@ -246,7 +246,7 @@
                 <div id="page-container" class="lg:flex lg:h-full container mx-auto">
                     @hasSection('sidebar')
                     <!-- Main Content (70% on desktop when sidebar present) -->
-                    <div class="lg:flex-1 lg:max-w-[70%] p-4 lg:p-4 xl:p-6">
+                    <div class="lg:flex-1 lg:max-w-[70%] p-4 lg:p-4 xl:p-6 pb-5 md:pb-20 lg:pb-4 xl:pb-6">
                         @yield('content')
                     </div>
 
@@ -256,7 +256,7 @@
                     </div>
                     @else
                     <!-- Full-width Content when no sidebar is defined -->
-                    <div class="flex-1 p-4 xl:p-6">
+                    <div class="flex-1 p-4 xl:p-6 pb-5 md:pb-20 lg:pb-6">
                         @yield('content')
                     </div>
                     @endif

--- a/resources/views/partials/infinite-scroll-sentinel.blade.php
+++ b/resources/views/partials/infinite-scroll-sentinel.blade.php
@@ -1,0 +1,15 @@
+{{-- Infinite Scroll Sentinel Partial --}}
+{{-- This partial renders the intersection observer element for infinite scroll --}}
+<div id="infinite-scroll-sentinel" 
+    hx-get="{{ $logs->nextPageUrl() }}" 
+    hx-trigger="intersect once" 
+    hx-target="#log-list-content"
+    hx-swap="beforeend"
+    hx-indicator=".htmx-indicator" 
+    class="flex justify-center py-4 mt-4">
+    {{-- Loading indicator that shows during fetch --}}
+    <div class="htmx-indicator flex items-center space-x-2 text-gray-500">
+        <div class="animate-spin h-5 w-5 border-2 border-primary-600 border-t-transparent rounded-full"></div>
+        <span class="text-sm">Loading more readings...</span>
+    </div>
+</div>

--- a/resources/views/partials/infinite-scroll-sentinel.blade.php
+++ b/resources/views/partials/infinite-scroll-sentinel.blade.php
@@ -6,7 +6,7 @@
     hx-target="#log-list-content"
     hx-swap="beforeend"
     hx-indicator=".htmx-indicator" 
-    class="flex justify-center py-4 mt-4">
+    class="absolute inset-x-0 h-0 flex justify-center items-center pointer-events-none">
     {{-- Loading indicator that shows during fetch --}}
     <div class="htmx-indicator flex items-center space-x-2 text-gray-500">
         <div class="animate-spin h-5 w-5 border-2 border-primary-600 border-t-transparent rounded-full"></div>

--- a/resources/views/partials/reading-log-list.blade.php
+++ b/resources/views/partials/reading-log-list.blade.php
@@ -23,19 +23,7 @@
         
         {{-- Intersection Observer Sentinel for Infinite Scroll --}}
         @if ($logs->hasMorePages())
-            <div id="infinite-scroll-sentinel" 
-                hx-get="{{ $logs->nextPageUrl() }}" 
-                hx-trigger="intersect once" 
-                hx-target="#log-list-content"
-                hx-swap="beforeend"
-                hx-indicator=".htmx-indicator" 
-                class="flex justify-center py-4 mt-4">
-                {{-- Loading indicator that shows during fetch --}}
-                <div class="htmx-indicator flex items-center space-x-2 text-gray-500">
-                    <div class="animate-spin h-5 w-5 border-2 border-primary-600 border-t-transparent rounded-full"></div>
-                    <span class="text-sm">Loading more readings...</span>
-                </div>
-            </div>
+            @include('partials.infinite-scroll-sentinel', compact('logs'))
         @endif
     </div>
 @else


### PR DESCRIPTION
- Added renderReadingLogCardsHtml() method to ReadingLogService for proper HTML rendering
- Created reusable infinite-scroll-sentinel.blade.php partial
- Enhanced infinite scroll architecture with proper sentinel management
- Fixed pagination URLs not updating after each content load
- Maintains consistent spacing and HTMX-native approach

🤖 Generated with [Claude Code](https://claude.ai/code)